### PR TITLE
Add summarize and history REST APIFeature/add rest routes

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -6,20 +6,28 @@ from runnables.summarize_runnable import summarize_runnable
 from runnables.chat_runnable import chat_runnable
 from runnables.tts_runnable import tts_runnable
 from runnables.stt_runnable import stt_runnable
+from routes import summarize, qa_router, chat_ws_router
 
 app = FastAPI()
 
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["*"],
+    allow_origins=["*"], 
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],
 )
 
+# 정적 파일 (mp3 저장된 audio 경로 포함)
 app.mount("/static", StaticFiles(directory="static"), name="static")
 
+# LangServe API 등록 
 add_routes(app, summarize_runnable, path="/lang/summarize")
 add_routes(app, chat_runnable, path="/lang/chat")
 add_routes(app, tts_runnable, path="/lang/tts")
 add_routes(app, stt_runnable, path="/lang/stt")
+
+# 일반 REST + WebSocket 라우터 등록
+app.include_router(summarize.router, prefix="/summarize")
+app.include_router(qa_router.router, prefix="/qa")
+app.include_router(chat_ws_router.router)

--- a/backend/routes/history_router.py
+++ b/backend/routes/history_router.py
@@ -1,0 +1,22 @@
+from fastapi import APIRouter, Request
+from db import SessionLocal
+from models import Summary
+
+router = APIRouter(prefix="/api", tags=["History"])
+
+@router.get("/history")
+def get_user_history(request: Request):
+    client_id = request.headers.get("X-Client-ID", "anonymous")
+
+    db = SessionLocal()
+    rows = db.query(Summary).filter_by(client_id=client_id).order_by(Summary.created_at.desc()).limit(5).all()
+    db.close()
+
+    return [
+        {
+            "summary_text": row.summary_text,
+            "audio_path": row.tts_path,
+            "created_at": row.created_at
+        }
+        for row in rows
+    ]

--- a/backend/routes/summarize.py
+++ b/backend/routes/summarize.py
@@ -1,12 +1,27 @@
-from fastapi import APIRouter, UploadFile, File
+from fastapi import APIRouter, UploadFile, File, Request
 from application.summarize_service import summarize_pipeline
+from db import SessionLocal
+from models import Summary
 
-router = APIRouter()
+router = APIRouter(prefix="/api", tags=["Summarize"])
 
-@router.post("/")
-async def summarize(file: UploadFile = File(...)):
+@router.post("/summarize")
+async def summarize_with_storage(request: Request,file: UploadFile = File(...)):
     image_bytes = await file.read()
+    client_id = request.headers.get("X-Client-ID", "anonymous")
+
     result = summarize_pipeline(image_bytes)
+
+    db = SessionLocal()
+    summary = Summary(
+        client_id=client_id,
+        original_text=result.original_text,
+        summary_text=result.summary_text,
+        tts_path=result.audio_path
+    )
+    db.add(summary)
+    db.commit()
+    db.close()
 
     return {
         "original_text": result.original_text,


### PR DESCRIPTION
 변경 사항
- `/api/summarize`: 문서 요약 및 TTS 결과 생성, DB 저장
- `/api/history`: client_id 기반 사용자별 요약 이력 조회

확인할 사항
- 로컬 SQLite DB 정상 작동 확인
- TTS mp3는 static/audio 경로에 저장됨
- 프론트에서 X-Client-ID 헤더로 사용자 구분

